### PR TITLE
Fix samples parameter

### DIFF
--- a/workflow/wgs_preprocess.wdl
+++ b/workflow/wgs_preprocess.wdl
@@ -848,7 +848,7 @@ task MochaBcftoolsMpileup {
                 -mv \
                 -f GQ \
                 ~{ploidy} \
-                ~{"--ploidy " + samples} \
+                ~{"--samples-file " + samples} \
                 -Oz \
                 -o ~{vcf_basename}.mpileup.unnorm.vcf.gz
             tabix -s 1 -b 2 -e 2 ~{vcf_basename}.mpileup.unnorm.vcf.gz

--- a/workflow/wgs_preprocess.wdl
+++ b/workflow/wgs_preprocess.wdl
@@ -819,7 +819,6 @@ task MochaBcftoolsMpileup {
     Int command_mem = (bcftools_mem - bcftools_mem_padding) * 1000
     String vcf_basename = basename(basename(vcf, ".gz"), ".vcf")
     String ploidy = if (ref_name == "GRCh38" || ref_name == "GRCh37") then "--ploidy ~{ref_name}" else ""
-    String samples_param = if (defined(samples)) then "--samples-file ~{samples}" else ""
     String regions_param = if (defined(regions)) then "-r ~{regions}" else ""
 
     command <<<
@@ -849,7 +848,7 @@ task MochaBcftoolsMpileup {
                 -mv \
                 -f GQ \
                 ~{ploidy} \
-                ~{samples_param} \
+                ~{"--ploidy " + samples} \
                 -Oz \
                 -o ~{vcf_basename}.mpileup.unnorm.vcf.gz
             tabix -s 1 -b 2 -e 2 ~{vcf_basename}.mpileup.unnorm.vcf.gz


### PR DESCRIPTION
The previous bcftools call task was creating a --samples-file parameter that included the gs:// string as the path, rather than the localised path. This update fixes that.